### PR TITLE
fix: export getLanguage to apply antiCrow.language setting correctly

### DIFF
--- a/src/configHelper.ts
+++ b/src/configHelper.ts
@@ -55,7 +55,7 @@ export function getConfig(): vscode.WorkspaceConfiguration {
 }
 
 /** i18n 言語設定を取得する（デフォルト: 'ja'） */
-function getLanguage(): string {
+export function getLanguage(): string {
     return getConfig().get<string>('language') || 'ja';
 }
 


### PR DESCRIPTION
fix: export getLanguage to apply antiCrow.language setting correctly